### PR TITLE
Add GCC build support for loader

### DIFF
--- a/Includes/Library/mx25lm51245g_conf_template.h
+++ b/Includes/Library/mx25lm51245g_conf_template.h
@@ -28,7 +28,7 @@
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32U5xx_hal.h"
+#include "stm32u5xx_hal.h"
 
 /** @addtogroup BSP
   * @{

--- a/Includes/Loader/loader.h
+++ b/Includes/Loader/loader.h
@@ -24,12 +24,17 @@
 #define __LOADER_SRC_H
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32U5xx_hal.h"
-#include "stm32U5xx_hal_ospi.h"
+#include "stm32u5xx_hal.h"
+#include "stm32u5xx_hal_ospi.h"
 
 
 #define TIMEOUT 5000U
+
+#if defined(__ICCARM__)
 #define KeepInCompilation __root
+#else
+#define KeepInCompilation __attribute__((used))
+#endif
 
 /* Private function prototypes -----------------------------------------------*/
 int Init ();

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CC=arm-none-eabi-gcc
+CFLAGS=-mcpu=cortex-m33 -mthumb -O2 -ffunction-sections -fdata-sections \
+       -IIncludes -IIncludes/Loader -IIncludes/Library -IIncludes/CMSIS
+LDFLAGS=-Tgcc/loader.ld -nostartfiles -specs=nosys.specs -Wl,--gc-sections
+
+SOURCES=$(wildcard Sources/Loader/*.c) $(wildcard Sources/Library/*.c)
+OBJECTS=$(SOURCES:.c=.o)
+
+all: loader.elf
+
+loader.elf: $(OBJECTS) gcc/loader.ld
+	$(CC) $(CFLAGS) $(OBJECTS) $(LDFLAGS) -o $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+
+clean:
+	rm -f $(OBJECTS) loader.elf
+
+.PHONY: all clean

--- a/Sources/Loader/Dev_Inf.c
+++ b/Sources/Loader/Dev_Inf.c
@@ -25,7 +25,7 @@
 #if defined (__ICCARM__)
 __root struct StorageInfo const StorageInfo  =  {
 #else
-struct StorageInfo const StorageInfo  =  {
+struct StorageInfo const StorageInfo __attribute__((used)) =  {
 #endif
    "MYFLASH_APROTECH",                                              // Device Name + DISCO Board name
    NOR_FLASH,                                               // Device Type

--- a/Sources/Loader/console.c
+++ b/Sources/Loader/console.c
@@ -1,7 +1,6 @@
 #include <stdarg.h>
 #include <inttypes.h>
 
-#pragma section=".bss"
 
 //#define SUPPORT_64BIT
 //#define SUPPORT_FLOAT

--- a/Sources/Loader/loader.c
+++ b/Sources/Loader/loader.c
@@ -2,7 +2,6 @@
 #include "loader.h"
 #include "console.h"
 
-#pragma section=".bss"
 
 /** @defgroup B_STM32U585I_IOT02_OSPI_Private_Functions Private Functions
   * @{
@@ -106,9 +105,16 @@ static void console_init (void)
 int Init()
 {
     /*  Init structs to Zero*/
-    char *   startadd =  __section_begin(".bss");
-    uint32_t size =  __section_size(".bss");
-    memset(startadd,0,size);
+#if defined(__ICCARM__)
+    char *startadd = __section_begin(".bss");
+    uint32_t size  = __section_size(".bss");
+#else
+    extern char __bss_start__;
+    extern char __bss_end__;
+    char *startadd = &__bss_start__;
+    uint32_t size  = &__bss_end__ - &__bss_start__;
+#endif
+    memset(startadd, 0, size);
 
     SystemInit();
     HAL_Init();

--- a/gcc/loader.ld
+++ b/gcc/loader.ld
@@ -1,0 +1,35 @@
+/* Linker script for GCC build */
+MEMORY
+{
+  INFO (r)  : ORIGIN = 0x00000000, LENGTH = 0x100
+  RAM  (rwx) : ORIGIN = 0x20000004, LENGTH = 0x3FFFC
+}
+
+ENTRY(Init)
+
+SECTIONS
+{
+  .text :
+  {
+    *(.text*)
+    *(.rodata*)
+  } > RAM
+
+  .data :
+  {
+    *(.data*)
+  } > RAM
+
+  .bss :
+  {
+    __bss_start__ = .;
+    *(.bss*)
+    *(COMMON)
+    __bss_end__ = .;
+  } > RAM
+
+  .info :
+  {
+    *(.info*)
+  } > INFO
+}

--- a/gcc/loader.ld
+++ b/gcc/loader.ld
@@ -1,8 +1,8 @@
 /* Linker script for GCC build */
 MEMORY
 {
-  INFO (r)  : ORIGIN = 0x00000000, LENGTH = 0x100
-  RAM  (rwx) : ORIGIN = 0x20000004, LENGTH = 0x3FFFC
+  INFOMEM (r)  : ORIGIN = 0x00000000, LENGTH = 0x100
+  RAM     (rwx) : ORIGIN = 0x20000004, LENGTH = 0x3FFFC
 }
 
 ENTRY(Init)
@@ -31,5 +31,5 @@ SECTIONS
   .info :
   {
     *(.info*)
-  } > INFO
+  } > INFOMEM
 }

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,8 @@
 
 ++ Hardware and Software Environment
 ------------------------------------
- - Build Toolchain : EWARM 8.50.9
+- Build Toolchain : EWARM 8.50.9
+- Alternate Build : GCC (arm-none-eabi). Run `make` at repository root.
  - HW : STM32U585I-IOT02A-Disco board rev Z
 
 The MX25LM51245G_STM32U585I-IOT02A.stldr has been successfully tested on CubeProgrammer v2.7 giving the following timing measurements:


### PR DESCRIPTION
## Summary
- add Makefile and GCC linker script to build with `arm-none-eabi-gcc`
- update headers to handle GCC compilation
- replace IAR pragmas and section APIs with GCC equivalents
- document GCC build option in `readme.txt`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_685763bbf17c832ba237a0557da21fb3